### PR TITLE
Only parse the mailer config file if it exists.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,15 +8,17 @@ Bundler.require(:default, Rails.env) if defined?(Bundler)
 
 module SignalCI
   class Application < Rails::Application
-    MAILER = YAML.load_file Rails.root.join("config/mailer.yml")
     config.encoding = "utf-8"
     config.filter_parameters += [:password]
     config.action_controller.page_cache_directory = Rails.root.join("public/cache")
-    config.action_mailer.smtp_settings = {
-      :address          => MAILER['address'],
-      :port             => MAILER['port'],
-      :domain           => MAILER['domain'],
-      :enable_starttls_auto => false
-    }
+    if Rails.root.join("config/mailer.yml").file?
+      MAILER = YAML.load_file(Rails.root.join("config/mailer.yml"))
+      config.action_mailer.smtp_settings = {
+        :address          => MAILER['address'],
+        :port             => MAILER['port'],
+        :domain           => MAILER['domain'],
+        :enable_starttls_auto => false
+      }
+    end
   end
 end


### PR DESCRIPTION
When first checking out the project, the rake inploy:local:setup task won't run due to the application.rb file expecting a mailer.yml to exist. This patch ensures the file does exist.
